### PR TITLE
Add text preprocessing for structured data

### DIFF
--- a/libra/preprocessing/data_preprocesser.py
+++ b/libra/preprocessing/data_preprocesser.py
@@ -9,6 +9,7 @@ from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler, FunctionTransformer
+from sklearn.feature_extraction.text import TfidfVectorizer
 from tensorflow import keras
 from tensorflow.python.keras.layers import Dense, Input
 from keras.callbacks import EarlyStopping
@@ -20,8 +21,13 @@ from libra.data_generation.grammartree import get_value_instruction
 import cv2
 from prince.ca import CA
 
+from nltk.stem import WordNetLemmatizer
+from nltk.tokenize import word_tokenize
+from nltk.corpus import stopwords
+from autocorrect import Speller
 
-def initial_preprocesser(data, instruction, preprocess, mca_threshold):
+
+def initial_preprocesser(data, instruction, preprocess, ca_threshold, text):
     # Scans for object columns just in case we have a datetime column that
     # isn't detected
     object_columns = [
@@ -55,7 +61,7 @@ def initial_preprocesser(data, instruction, preprocess, mca_threshold):
     # preprocess the dataset
     full_pipeline = None
     if preprocess:
-        data, full_pipeline = structured_preprocesser(data, mca_threshold)
+        data, full_pipeline = structured_preprocesser(data, ca_threshold, text)
     else:
         data.fillna(0, inplace=True)
 
@@ -64,10 +70,16 @@ def initial_preprocesser(data, instruction, preprocess, mca_threshold):
     return data, y, target, full_pipeline
 
 
-# Preprocesses the data appropriately for single reg data
-def structured_preprocesser(data, mca_threshold):
+def structured_preprocesser(data, ca_threshold, text):
+
     # Preprocessing for datetime columns
     process_dates(data)
+
+    # Preprocessing for cols with text (work in progress)
+    # process_text(data)
+    # This will be used inside process_text once complete
+    if len(text) > 0:
+        text_preprocessing(data, text)
 
     # identifies the categorical and numerical columns
     categorical_columns = data['train'].select_dtypes(
@@ -75,28 +87,54 @@ def structured_preprocesser(data, mca_threshold):
     numeric_columns = data['train'].columns[data['train'].dtypes.apply(
         lambda c: np.issubdtype(c, np.number))]
 
-    # pipeline for numeric columns
-    num_pipeline = Pipeline([
-        ('imputer', SimpleImputer(strategy="median")),
-        ('std_scaler', StandardScaler())
-    ])
+    # Removes text columns from categorical columns to use in separate pipeline
+    categorical_columns = [cat_cols for cat_cols in categorical_columns if cat_cols not in text]
 
     full_pipeline = ColumnTransformer([], remainder="passthrough")
 
     if len(numeric_columns) != 0:
+        # pipeline for numeric columns
+        num_pipeline = Pipeline([
+            ('imputer', SimpleImputer(strategy="median")),
+            ('std_scaler', StandardScaler())
+        ])
+
         full_pipeline.transformers.append(("num", num_pipeline, numeric_columns))
+
+    if len(text) != 0:
+        print(categorical_columns)
+        # Each text col needs a separate pipeline
+        for x in range(len(text)):
+            full_pipeline.transformers.append((f"text_{x}",
+                                               Pipeline([
+                                                   ('test',
+                                                    FunctionTransformer(lambda x: np.reshape(x.to_numpy(), (-1,1)))),
+
+                                                   ('imputer', SimpleImputer(strategy="constant", fill_value="")),
+
+                                                   ('raveler',
+                                                    FunctionTransformer(lambda x: x.ravel(), accept_sparse=True)),
+
+                                                   ('vect', TfidfVectorizer()),
+
+                                                   ('densifier',
+                                                    FunctionTransformer(lambda x: x.todense(), accept_sparse=True)),
+
+                                                   ('embedder', FunctionTransformer(text_embedder, accept_sparse=True))
+                                               ]),
+                                               text[x]))
 
     if len(categorical_columns) != 0:
         combined = pd.concat([data['train'], data['test']], axis=0)
 
-        mca_threshold = combined.shape[0]*.25 if mca_threshold is None else combined.shape[0] * mca_threshold
+        ca_threshold = combined.shape[0] * .25 if ca_threshold is None else combined.shape[0] * ca_threshold
 
-        if too_many_values(combined[categorical_columns], mca_threshold):
+        if too_many_values(combined[categorical_columns], ca_threshold):
             cat_pipeline = Pipeline([
                 ('imputer', SimpleImputer(strategy="constant", fill_value="")),
                 ('one_hot_encoder', OneHotEncoder(handle_unknown='ignore')),
                 ('transformer', FunctionTransformer(lambda x: x.toarray(), accept_sparse=True)),
-                ('mca', CA(n_components=-1))
+                ('ca', CA(n_components=-1))
             ])
         else:
             cat_pipeline = Pipeline([
@@ -108,11 +146,11 @@ def structured_preprocesser(data, mca_threshold):
 
     train = full_pipeline.fit_transform(data['train'])
 
-    train_cols = generate_column_labels(full_pipeline, numeric_columns)
+    train_cols = generate_column_labels(full_pipeline, numeric_columns, text)
 
     test = full_pipeline.transform(data['test'])
 
-    test_cols = generate_column_labels(full_pipeline, numeric_columns)
+    test_cols = generate_column_labels(full_pipeline, numeric_columns, text)
 
     # Ternary clause because when running housing.csv,
     # the product of preprocessing is np array, but not when using landslide
@@ -127,7 +165,7 @@ def structured_preprocesser(data, mca_threshold):
             test,
             np.ndarray) else test),
         columns=test_cols)
-
+    print(data['train'])
     return data, full_pipeline
 
 
@@ -144,21 +182,97 @@ def process_dates(data):
             del df[col]
 
 
+# # Checks columns for text
+# # Converts text to numbers using TF-IDF
+# def process_text(data):
+#
+#     combined = pd.concat([data['train'], data['test']], axis=0)
+#
+#     combined.dropna(inplace=True)
+#
+#     possible_text_cols = combined.select_dtypes(
+#         exclude=["number"]).columns
+#     text_cols = list()
+#
+#     # Scans categorical columns for text
+#     for col in possible_text_cols:
+#         print(len(pd.unique(combined[col])))
+#         print(len(combined))
+#         print("\n\n")
+#         if len(np.unique(combined[col])) == len(combined):
+#             text_cols.append(col)
+#
+#     print(text_cols)
+#     #text_preprocessing()
+
+
+# Returns True if text has more than 3 spaces
+# Otherwise false
+# def find_spaces(text):
+#     spaces = 0
+#     for i in text:
+#         if spaces > 3:
+#             return True
+#         if i.isspace():
+#             spaces += 1
+#     return False
+
+
+# Preprocesses text for word embedding
+def text_preprocessing(data, text_cols):
+
+    lemmatizer = WordNetLemmatizer()
+    combined = pd.concat([data['train'], data['test']], axis=0)
+
+    spell = Speller(fast=True)
+    for col in text_cols:
+        combined[col] = combined[col].apply(lambda x: x.lower() if isinstance(x, str) else x)
+
+    stop_words = set(stopwords.words('english'))
+
+    for col in text_cols:
+        preprocessed_text = []
+        for words in combined[col]:
+            if words is not np.nan:
+                words = word_tokenize(words)
+                words = [word for word in words if word.isalpha()]
+                words = [word for word in words if word not in stop_words]
+                words = [spell(word) for word in words]
+                words = [lemmatizer.lemmatize(word) for word in words]
+                
+                preprocessed_text.append(' '.join(words))
+
+            else:
+                preprocessed_text.append(np.nan)
+
+        combined[col] = preprocessed_text
+    data['train'] = combined.iloc[:len(data['train'])]
+    data['test'] = combined.iloc[len(data['train']):]
+
+
+def text_embedder(text):
+
+    total = list()
+    for i in text:
+        total.append(np.sum(i))
+
+    return np.reshape(total, (-1,1))
+
 # Sees if one hot encoding occurred, if not just uses numeric cols
-def generate_column_labels(pipeline, numeric_cols):
+def generate_column_labels(full_pipeline, numeric_cols, text_cols):
     # Check if one hot encoding was performed
-    if 'cat' in pipeline.named_transformers_:
-        # If mca was used
-        if isinstance(pipeline.named_transformers_['cat'][-1], CA):
-            ca = pipeline.named_transformers_['cat'][-1]
+    if 'cat' in full_pipeline.named_transformers_:
+        # If ca was used
+        if isinstance(full_pipeline.named_transformers_['cat'][-1], CA):
+            ca = full_pipeline.named_transformers_['cat'][-1]
             encoded_cols = [f'CA_{x}' for x in range(len(ca.eigenvalues_))]
-            cols = [*list(numeric_cols), *encoded_cols]
+            cols = [*list(numeric_cols), *encoded_cols, *text_cols]
 
         else:
             try:
-                encoded_cols = pipeline.named_transformers_[
+                encoded_cols = full_pipeline.named_transformers_[
                     'cat']['one_hot_encoder'].get_feature_names()
-                cols = [*list(numeric_cols), *encoded_cols]
+                cols = [*list(numeric_cols), *encoded_cols, *text_cols]
 
             except Exception as error:
                 # For debugging only
@@ -212,14 +326,14 @@ def clustering_preprocessor(data):
 
 # Method to calculate how many columns the data set will
 # have after one hot encoding
-# Decides whether MCA is needed or not essentially
+# Decides whether CA is needed or not essentially
 # mca_threshold is the len of the dataset * .25 to calculate the proportion of
-# when to apply MCA
-def too_many_values(data, mca_threshold):
+# when to apply CA
+def too_many_values(data, ca_threshold):
     total_unique = 0
     for col in data:
 
-        if total_unique > mca_threshold: return True
+        if total_unique > ca_threshold: return True
         # Use value_counts() due to same columns having strings and floats
         total_unique += len(data[col].value_counts())
 

--- a/libra/preprocessing/data_preprocesser.py
+++ b/libra/preprocessing/data_preprocesser.py
@@ -75,8 +75,6 @@ def structured_preprocesser(data, ca_threshold, text):
     # Preprocessing for datetime columns
     process_dates(data)
 
-    # Preprocessing for cols with text (work in progress)
-    # process_text(data)
     # This will be used inside process_text once complete
     if len(text) > 0:
         text_preprocessing(data, text)
@@ -180,43 +178,6 @@ def process_dates(data):
             df[f'{col}_MonthDay'] = df[col].dt.day
 
             del df[col]
-
-
-# # Checks columns for text
-# # Converts text to numbers using TF-IDF
-# def process_text(data):
-#
-#     combined = pd.concat([data['train'], data['test']], axis=0)
-#
-#     combined.dropna(inplace=True)
-#
-#     possible_text_cols = combined.select_dtypes(
-#         exclude=["number"]).columns
-#     text_cols = list()
-#
-#     # Scans categorical columns for text
-#     for col in possible_text_cols:
-#         print(len(pd.unique(combined[col])))
-#         print(len(combined))
-#         print("\n\n")
-#         if len(np.unique(combined[col])) == len(combined):
-#             text_cols.append(col)
-#
-#     print(text_cols)
-#     #text_preprocessing()
-
-
-# Returns True if text has more than 3 spaces
-# Otherwise false
-# def find_spaces(text):
-#     spaces = 0
-#     for i in text:
-#         if spaces > 3:
-#             return True
-#         if i.isspace():
-#             spaces += 1
-#     return False
-
 
 # Preprocesses text for word embedding
 def text_preprocessing(data, text_cols):

--- a/libra/queries/classification_models.py
+++ b/libra/queries/classification_models.py
@@ -140,13 +140,14 @@ def k_means_clustering(dataset= None,
 
 
 def train_svm(instruction,
-        dataset=None,
-            test_size=0.2,
-            kernel='linear',
-            preprocess=True,
-            mca_threshold=None,
-            drop=None,
-            cross_val_size=0.3):
+              dataset=None,
+              test_size=0.2,
+              kernel='linear',
+              text=None,
+              preprocess=True,
+              ca_threshold=None,
+              drop=None,
+              cross_val_size=0.3):
 
         logger("Reading in dataset....")
         # reads dataset and fills n/a values with zeroes
@@ -158,7 +159,7 @@ def train_svm(instruction,
         if drop is not None:
             data.drop(drop, axis=1, inplace=True)
 
-        data, y, target, full_pipeline = initial_preprocesser(data, instruction, preprocess, mca_threshold)
+        data, y, target, full_pipeline = initial_preprocesser(data, instruction, preprocess, ca_threshold, text)
         logger("->", "Target Column Found: {}".format(target))
 
 
@@ -210,12 +211,12 @@ def train_svm(instruction,
 
 
 def nearest_neighbors(instruction=None,
-            dataset = None,
-            mca_threshold=None,
-            preprocess=True,
-            drop=None,
-            min_neighbors=3,
-            max_neighbors=10):
+                      dataset = None,
+                      ca_threshold=None,
+                      preprocess=True,
+                      drop=None,
+                      min_neighbors=3,
+                      max_neighbors=10):
         logger("Reading in dataset....")
         # Reads in dataset
         # data = pd.read_csv(self.dataset)
@@ -224,7 +225,7 @@ def nearest_neighbors(instruction=None,
         if drop is not None:
             data.drop(drop, axis=1, inplace=True)
         data, y, remove, full_pipeline = initial_preprocesser(
-            data, instruction, preprocess, mca_threshold)
+            data, instruction, preprocess, ca_threshold, text)
         logger("->", "Target Column Found: {}".format(remove))
         X_train = data['train']
         y_train = y['train']
@@ -263,11 +264,12 @@ def nearest_neighbors(instruction=None,
         clearLog()
 
 def decision_tree(instruction,
-            dataset=None,
-            preprocess=True,
-            mca_threshold=None,
-            test_size=0.2,
-            drop=None):
+                  dataset=None,
+                  preprocess=True,
+                  ca_threshold=None,
+                  text=None,
+                  test_size=0.2,
+                  drop=None):
     logger("Reading in dataset....")
 
     dataReader = DataReader(dataset)
@@ -277,7 +279,7 @@ def decision_tree(instruction,
         data.drop(drop, axis=1, inplace=True)
 
     data, y, remove, full_pipeline = initial_preprocesser(
-        data, instruction, preprocess, mca_threshold)
+        data, instruction, preprocess, ca_threshold, text)
     logger("->", "Target Column Found: {}".format(remove))
 
     X_train = data['train']

--- a/libra/queries/dimensionality_red_queries.py
+++ b/libra/queries/dimensionality_red_queries.py
@@ -207,13 +207,13 @@ def dimensionality_RF(instruction, dataset, target="", y="", n_features=10):
         accuracy_scores), list(columns[the_index])
 
 
-def dimensionality_PCA(instruction, dataset, mca_threshold=None):
+def dimensionality_PCA(instruction, dataset, ca_threshold=None):
     global currLog
     global counter
 
     pca = PCA(0.92)
 
-    data, y, target, full_pipeline = initial_preprocesser(dataset, instruction, mca_threshold=mca_threshold, preprocess=True)
+    data, y, target, full_pipeline = initial_preprocesser(dataset, instruction, ca_threshold=ca_threshold, preprocess=True)
 
     X_train = data['train']
     X_test = data['test']

--- a/libra/queries/feedforward_nn.py
+++ b/libra/queries/feedforward_nn.py
@@ -73,7 +73,8 @@ def logger(instruction, found=""):
 
 def regression_ann(
         instruction,
-        mca_threshold=None,
+        ca_threshold=None,
+        text=None,
         dataset=None,
         drop=None,
         preprocess=True,
@@ -87,8 +88,7 @@ def regression_ann(
         save_path=os.getcwd()):
 
     global currLog
-    global counter
-    logger("Reading in dataset...")
+    logger("reading in dataset...")
 
     dataReader = DataReader(dataset)
     data = dataReader.data_generator()
@@ -97,9 +97,9 @@ def regression_ann(
     if drop is not None:
         data.drop(drop, axis=1, inplace=True)
 
-    data, y, target, full_pipeline = initial_preprocesser(
-        data, instruction, preprocess, mca_threshold)
+    data, y, target, full_pipeline = initial_preprocesser(data, instruction, preprocess, ca_threshold, text)
     logger("->", "Target Column Found: {}".format(target))
+
     X_train = data['train']
     X_test = data['test']
 
@@ -237,7 +237,8 @@ def regression_ann(
 
 def classification_ann(instruction,
                        dataset=None,
-                       mca_threshold=None,
+                       text=None,
+                       ca_threshold=None,
                        preprocess=True,
                        callback_mode='min',
                        drop=None,
@@ -259,7 +260,7 @@ def classification_ann(instruction,
         data.drop(drop, axis=1, inplace=True)
 
     data, y, remove, full_pipeline = initial_preprocesser(
-        data, instruction, preprocess, mca_threshold)
+        data, instruction, preprocess, ca_threshold, text)
     logger("->", "Target Column Found: {}".format(remove))
 
     # Needed to make a custom label encoder due to train test split changes
@@ -405,6 +406,7 @@ def classification_ann(instruction,
 
 def convolutional(instruction=None,
                   read_mode=None,
+                  text=None,
                   data_path=os.getcwd(),
                   new_folders=True,
                   image_column=None,

--- a/libra/queries/prediction_queries.py
+++ b/libra/queries/prediction_queries.py
@@ -94,7 +94,8 @@ class client:
 
     def neural_network_query(self,
                              instruction,
-                             mca_threshold=None,
+                             text=None,
+                             ca_threshold=None,
                              drop=None,
                              preprocess=True,
                              test_size=0.2,
@@ -112,12 +113,13 @@ class client:
 
             remove = get_similar_column(
                 get_value_instruction(instruction), data)
-            if (data[remove].dtype.name == 'object'):
+            if data[remove].dtype.name == 'object':
                 callback_mode = 'max'
                 maximizer = "val_accuracy"
                 self.classification_query_ann(
                     instruction,
-                    mca_threshold=mca_threshold,
+                    text=text,
+                    ca_threshold=ca_threshold,
                     preprocess=preprocess,
                     test_size=test_size,
                     random_state=random_state,
@@ -130,7 +132,8 @@ class client:
             else:
                 self.regression_query_ann(
                     instruction,
-                    mca_threshold=mca_threshold,
+                    text=text,
+                    ca_threshold=ca_threshold,
                     preprocess=preprocess,
                     test_size=test_size,
                     random_state=random_state,
@@ -147,8 +150,9 @@ class client:
     def regression_query_ann(
             self,
             instruction,
+            text=None,
             drop=None,
-            mca_threshold=None,
+            ca_threshold=None,
             preprocess=True,
             test_size=0.2,
             random_state=49,
@@ -161,8 +165,9 @@ class client:
 
         self.models['regression_ANN'] = regression_ann(
             instruction=instruction,
-            mca_threshold=.25 if mca_threshold is None else mca_threshold,
+            ca_threshold=.25 if ca_threshold is None else ca_threshold,
             dataset=self.dataset,
+            text=text,
             drop=drop,
             preprocess=preprocess,
             test_size=test_size,
@@ -179,7 +184,8 @@ class client:
     def classification_query_ann(
             self,
             instruction,
-            mca_threshold=None,
+            text=None,
+            ca_threshold=None,
             preprocess=True,
             callback_mode='min',
             drop=None,
@@ -194,7 +200,8 @@ class client:
         self.models['classification_ANN'] = classification_ann(
             instruction=instruction,
             dataset=self.dataset,
-            mca_threshold=.25 if mca_threshold is None else mca_threshold,
+            text=text,
+            ca_threshold=.25 if ca_threshold is None else ca_threshold,
             drop=drop,
             preprocess=preprocess,
             test_size=test_size,
@@ -222,6 +229,7 @@ class client:
     def svm_query(self,
                   instruction,
                   test_size=0.2,
+                  text=None,
                   kernel='linear',
                   preprocess=True,
                   drop=None,
@@ -229,6 +237,7 @@ class client:
 
         self.models['svm'] = train_svm(instruction,
                                        dataset=self.dataset,
+                                       text=text,
                                        test_size=test_size,
                                        kernel=kernel,
                                        preprocess=preprocess,
@@ -237,6 +246,7 @@ class client:
 
     def nearest_neighbor_query(
             self,
+            text=None,
             instruction=None,
             preprocess=True,
             drop=None,
@@ -244,6 +254,7 @@ class client:
             max_neighbors=10):
         self.models['nearest_neigbor'] = nearest_neighbors(
             instruction=instruction,
+            text=text,
             dataset=self.dataset,
             preprocess=preprocess,
             drop=drop,
@@ -258,6 +269,7 @@ class client:
             drop=None):
 
         self.models['decision_tree'] = decision_tree(instruction,
+                                                     text=None,
                                                      dataset=self.dataset,
                                                      preprocess=True,
                                                      test_size=0.2,
@@ -414,9 +426,12 @@ class client:
 # Easier to comment the one you don't want to run instead of typing them
 # out every time
 
-newClient = client('/Users/palashshah/Desktop')
-newClient.convolutional_query()
-newClient.tune('convolutional_NN', epochs=1)
+# newClient = client('/Users/palashshah/Desktop')
+# newClient.convolutional_query()
+# newClient.tune('convolutional_NN', epochs=1)
 # newClient.neural_network_query("Model median house value")
 # newClient = client('tools/data/structured_data/landslides_after_rainfall.csv').neural_network_query(instruction='Model distance',
 # drop=['id', 'geolocation', 'source_link', 'source_name'])
+newClient = client('tools/data/structured_data/fake_job_postings.csv').neural_network_query(instruction='Classify fraudulent',
+                                                                                            drop=['job_id'],
+                                                                                            text=['department','description', 'company_profile','requirements', 'benefits'])

--- a/libra/queries/unused_functions.py
+++ b/libra/queries/unused_functions.py
@@ -188,3 +188,46 @@ history = model.fit_generator(
         X_test.batch_size, workers=4
     )
 """
+
+
+
+
+
+
+
+
+
+# # Checks columns for text
+# # Converts text to numbers using TF-IDF
+# def process_text(data):
+#
+#     combined = pd.concat([data['train'], data['test']], axis=0)
+#
+#     combined.dropna(inplace=True)
+#
+#     possible_text_cols = combined.select_dtypes(
+#         exclude=["number"]).columns
+#     text_cols = list()
+#
+#     # Scans categorical columns for text
+#     for col in possible_text_cols:
+#         print(len(pd.unique(combined[col])))
+#         print(len(combined))
+#         print("\n\n")
+#         if len(np.unique(combined[col])) == len(combined):
+#             text_cols.append(col)
+#
+#     print(text_cols)
+#     #text_preprocessing()
+
+
+# Returns True if text has more than 3 spaces
+# Otherwise false
+# def find_spaces(text):
+#     spaces = 0
+#     for i in text:
+#         if spaces > 3:
+#             return True
+#         if i.isspace():
+#             spaces += 1
+#     return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ pandas
 sklearn
 pprint
 matplotlib
-os
-itertools
 tabulate
 textblob
 python-Levenshtein
@@ -14,3 +12,4 @@ seaborn
 keras-tuner
 spacy
 torch
+autocorrect


### PR DESCRIPTION
Also includes changing mca_threshold to ca_threshold in various places

---
Add text preprocessing for structured data
Applies NLP techniques to specified columns within structured data and creates a scalar value for the sum of the tf-idf vector
---

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Palashio/libra/CONTRIBUTING.md
-->

This pull request closes #93

**- What I did**
Used NLTK library for tokenize, filter stop words, and convert each word to it's respective lemma
Used autocorrect's speller to fix mispellings
Used sklearn's TF-IDF vectorizer to give weight to the rarer words
**- How I did it**
I coded
**- How to verify it**

Include text based columns that you do not want one hot encoded in the text param for the different models



- [ ] I updated the docs.

This pull request adds a new feature to Libra. @Palashio, could you please take a look at it?
