### PR TITLE
Add names and usercols params to dataset

### DIFF
--- a/libra/queries.py
+++ b/libra/queries.py
@@ -175,7 +175,7 @@ class client:
         :return: a model, plots, accuracy information all stored in the self.models dictionary
         '''
 
-        data = pd.read_csv(self.dataset)
+        data = pd.read_csv(self.dataset, names=None, usecols=None)
 
         if preprocess:
 
@@ -818,7 +818,7 @@ class client:
         return ' '.join(caption[:len(caption) - 1])
 
     # image_caption prediction query
-    def image_caption_query(self, instruction,label_column=None,
+    def image_caption_query(self, instruction, label_column=None,
                             drop=None,
                             epochs=10,
                             preprocess=True,


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Palashio/libra/CONTRIBUTING.md
-->

**- What I did**
Some datesets haven't column name and if we use those dataset Libra select first row so it's wrong. If we add usercols and names params we can create column name or we can select 
**- How I did it**
So pandas lib. have this two args
data = pd.read_csv(self.dataset, names=None, usecols=None)
**- How to verify it**
 - Firstly I try without column names (libra default version) and I got some problem with result
 - Change the pd.read_csv(self.dataset) to pd.read_csv(self.dataset, names=None, usecols=None) and try again and I solve this problem
<!-- 
You need a good justification for not 
including tests for the new feature you added. 
-->


- [x] I updated the docs.

This pull request adds a new feature to libra. @Palashio, could you please take a look at it?
